### PR TITLE
Add an example to clone from one merchant account to another.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ token:
 2. Click "New Application".
 3. Create an application with the name "Catalog API Demo".
 4. Copy the Personal Access Token that is generated and save it to an
-  environment variable: `export SQPAT={{ YOUR NEW ACCESS TOKEN }} ;`
+  environment variable:
+   
+   `export SQPAT={{ YOUR NEW ACCESS TOKEN }}`
 
 ## STEP 2: Compile the demo
 

--- a/src/main/java/com/squareup/catalog/demo/Main.java
+++ b/src/main/java/com/squareup/catalog/demo/Main.java
@@ -17,6 +17,7 @@ package com.squareup.catalog.demo;
 
 import com.google.gson.JsonSyntaxException;
 import com.squareup.catalog.demo.example.ApplyTaxToAllIItemsExample;
+import com.squareup.catalog.demo.example.clone.CloneCatalogExample;
 import com.squareup.catalog.demo.example.CreateItemExample;
 import com.squareup.catalog.demo.example.DeduplicateTaxesExample;
 import com.squareup.catalog.demo.example.DeleteAllItemsExample;
@@ -74,6 +75,7 @@ public class Main {
   public static void main(String[] args) {
     Main main = new Main(new Logger.SystemLogger(),
         new ApplyTaxToAllIItemsExample(),
+        new CloneCatalogExample(),
         new CreateItemExample(),
         new DeduplicateTaxesExample(),
         new DeleteAllItemsExample(),

--- a/src/main/java/com/squareup/catalog/demo/example/ApplyTaxToAllIItemsExample.java
+++ b/src/main/java/com/squareup/catalog/demo/example/ApplyTaxToAllIItemsExample.java
@@ -28,6 +28,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static com.squareup.connect.models.CatalogItem.ProductTypeEnum.REGULAR;
+import static com.squareup.connect.models.CatalogObjectType.ITEM;
+import static com.squareup.connect.models.CatalogObjectType.TAX;
 
 /**
  * This example shows a list of taxes to choose from, then applies the selected tax to
@@ -68,7 +70,7 @@ public class ApplyTaxToAllIItemsExample extends Example {
     String cursor = null;
     do {
       // Retrieve a page of taxes
-      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, "TAX");
+      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, TAX.toString());
       if (checkAndLogErrors(listResponse.getErrors())) {
         return null;
       }
@@ -99,7 +101,7 @@ public class ApplyTaxToAllIItemsExample extends Example {
 
     // Prompt the user to select a tax.
     String userTaxIndex = promptUserInput("Select a tax to apply to all items: ");
-    int taxIndex = -1;
+    int taxIndex;
     try {
       taxIndex = Integer.parseInt(userTaxIndex);
     } catch (NumberFormatException e) {
@@ -129,7 +131,7 @@ public class ApplyTaxToAllIItemsExample extends Example {
     final long startTimeMillis = System.currentTimeMillis();
     do {
       // Retrieve a page of items.
-      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, "ITEM");
+      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, ITEM.toString());
       if (checkAndLogErrors(listResponse.getErrors())) {
         return;
       }

--- a/src/main/java/com/squareup/catalog/demo/example/DeduplicateTaxesExample.java
+++ b/src/main/java/com/squareup/catalog/demo/example/DeduplicateTaxesExample.java
@@ -34,6 +34,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 
+import static com.squareup.connect.models.CatalogObjectType.TAX;
+
 /**
  * This example merges identical taxes (same name, percentage, and inclusion type).
  */
@@ -57,7 +59,7 @@ public class DeduplicateTaxesExample extends Example {
     String cursor = null;
     do {
       // Retrieve a page of taxes.
-      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, "TAX");
+      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, TAX.toString());
       if (checkAndLogErrors(listResponse.getErrors())) {
         return;
       }

--- a/src/main/java/com/squareup/catalog/demo/example/DeleteAllItemsExample.java
+++ b/src/main/java/com/squareup/catalog/demo/example/DeleteAllItemsExample.java
@@ -24,6 +24,8 @@ import com.squareup.connect.models.CatalogObject;
 import com.squareup.connect.models.ListCatalogResponse;
 import java.util.List;
 
+import static com.squareup.connect.models.CatalogObjectType.ITEM;
+
 /**
  * This example deletes all items and variations in a merchant's Item Library.
  */
@@ -52,7 +54,7 @@ public class DeleteAllItemsExample extends Example {
     final long startTimeMillis = System.currentTimeMillis();
     do {
       // Retrieve a page of items.
-      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, "ITEM");
+      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, ITEM.toString());
       if (checkAndLogErrors(listResponse.getErrors())) {
         return;
       }

--- a/src/main/java/com/squareup/catalog/demo/example/Example.java
+++ b/src/main/java/com/squareup/catalog/demo/example/Example.java
@@ -144,4 +144,22 @@ public abstract class Example {
       throw new RuntimeException(e);
     }
   }
+
+  /**
+   * Display a message prompting the user to answer a yes or no question.
+   *
+   * @param message the message displayed the user
+   * @return true if yes, false if no
+   */
+  protected boolean promptUserInputYesNo(String message) {
+    String response = promptUserInput(message).trim();
+    if (response.equalsIgnoreCase("y") || response.equalsIgnoreCase("yes")) {
+      return true;
+    } else if (response.equalsIgnoreCase("n") || response.equalsIgnoreCase("no")) {
+      return false;
+    }
+
+    logger.error("Please enter Y or N");
+    throw new IllegalArgumentException("Invalid text entered for yes/no question");
+  }
 }

--- a/src/main/java/com/squareup/catalog/demo/example/ListDiscountsExample.java
+++ b/src/main/java/com/squareup/catalog/demo/example/ListDiscountsExample.java
@@ -22,7 +22,8 @@ import com.squareup.connect.api.LocationsApi;
 import com.squareup.connect.models.CatalogDiscount;
 import com.squareup.connect.models.CatalogObject;
 import com.squareup.connect.models.ListCatalogResponse;
-import java.util.List;
+
+import static com.squareup.connect.models.CatalogObjectType.DISCOUNT;
 
 /**
  * This example lists all discounts in the catalog.
@@ -38,7 +39,7 @@ public class ListDiscountsExample extends Example {
     String cursor = null;
     do {
       // Retrieve a page of discounts.
-      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, "DISCOUNT");
+      ListCatalogResponse listResponse = catalogApi.listCatalog(cursor, DISCOUNT.toString());
       if (checkAndLogErrors(listResponse.getErrors())) {
         return;
       }

--- a/src/main/java/com/squareup/catalog/demo/example/clone/CatalogObjectCloneUtil.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/CatalogObjectCloneUtil.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.Money;
+import java.util.Collections;
+import java.util.UUID;
+
+/**
+ * Defines utility methods used when cloning a CatalogObject from one merchant account to another.
+ *
+ * @param <T> The catalog object data type
+ */
+abstract class CatalogObjectCloneUtil<T> {
+
+  final CatalogObject.TypeEnum type;
+
+  CatalogObjectCloneUtil(CatalogObject.TypeEnum type) {
+    this.type = type;
+  }
+
+  /**
+   * Returns the type specific data from a catalog object.
+   */
+  abstract T getCatalogData(CatalogObject catalogObject);
+
+  /**
+   * Encodes a subset of fields from the {@link CatalogObject} into a string, allowing
+   * CatalogObjects to be compared between merchant accounts for likeness. If the encoded string of
+   * a {@link CatalogObject} in the source account matches the encoded string of a {@link
+   * CatalogObject} in the target account, then the object is not cloned.
+   */
+  final String encodeCatalogObject(CatalogObject catalogObject) {
+    T catalogData = getCatalogData(catalogObject);
+    return encodeCatalogData(catalogData);
+  }
+
+  /**
+   * Encodes a subset of fields from the {@link CatalogObject} into a string, allowing
+   * CatalogObjects to be compared between merchant accounts for likeness. If the encoded string of
+   * a {@link CatalogObject} in the source account matches the encoded string of a {@link
+   * CatalogObject} in the target account, then the object is not cloned.
+   *
+   * @param catalogData the data from the {@link CatalogObject}.
+   */
+  abstract String encodeCatalogData(T catalogData);
+
+  /**
+   * Encodes a {@link Money} object to a string.
+   *
+   * @param money the {@link Money} object to encode
+   * @return the amount as a string, or null if the {@link Money} object is null
+   */
+  String amountOrNull(Money money) {
+    return (money == null) ? "null" : money.getAmount().toString();
+  }
+
+  /**
+   * Removes meta data from the {@link CatalogObject} that only applies to the source account, such
+   * as location IDs and version.
+   *
+   * @param catalogObject the {@link CatalogObject} to modify
+   */
+  void removeSourceAccountMetaData(CatalogObject catalogObject) {
+    // We need to set a temporary client generated ID.
+    catalogObject.setId("#" + UUID.randomUUID());
+
+    // The V1 IDs from the source account do not apply to the target account.
+    catalogObject.setCatalogV1Ids(Collections.emptyList());
+
+    // The location IDs from the source account do not apply to the target account.
+    catalogObject.setPresentAtLocationIds(Collections.emptyList());
+    catalogObject.setAbsentAtLocationIds(Collections.emptyList());
+
+    // The server will assign a version.
+    catalogObject.setVersion(null);
+
+    // The server will update the timestamp.
+    catalogObject.setUpdatedAt(null);
+  }
+
+  /**
+   * Merges data from a {@link CatalogObject} from the source account into a {@link CatalogObject}
+   * from the target account when they have the same encoded string. This method can be used to
+   * merge two objects that have the same name, but slightly different attributes. For example, if a
+   * modifier list in the source account has the same name as a modifier list in the target account,
+   * this method is used to copy the modifiers from the source account to the target account.
+   *
+   * @param sourceCatalogObject the {@link CatalogObject} from the source account
+   * @param targetCatalogObject the {@link CatalogObject} from the target account
+   * @return the modifier target {@link CatalogObject}, or null if nothing changed
+   */
+  CatalogObject mergeSourceCatalogObjectIntoTarget(CatalogObject sourceCatalogObject,
+      CatalogObject targetCatalogObject) {
+    // Default implementation assumes that the objects do not need to be merged.
+    return null;
+  }
+}

--- a/src/main/java/com/squareup/catalog/demo/example/clone/CloneCatalogExample.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/CloneCatalogExample.java
@@ -1,0 +1,295 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.catalog.demo.example.Example;
+import com.squareup.connect.ApiClient;
+import com.squareup.connect.ApiException;
+import com.squareup.connect.api.CatalogApi;
+import com.squareup.connect.api.LocationsApi;
+import com.squareup.connect.auth.OAuth;
+import com.squareup.connect.models.BatchUpsertCatalogObjectsRequest;
+import com.squareup.connect.models.BatchUpsertCatalogObjectsResponse;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.CatalogObjectBatch;
+import com.squareup.connect.models.ListCatalogResponse;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.UUID;
+
+/**
+ * This example clones catalog objects from one merchant account to another. The accessToken
+ * specified when the script is executed is assumed to be the source account from which catalog
+ * objects are copied.
+ *
+ * NOTE: This example is in development. Currently it only clones discounts, modifier lists, and
+ * taxes. Items are not yet cloned.
+ */
+public class CloneCatalogExample extends Example {
+
+  public CloneCatalogExample() {
+    super("clone_catalog", "Clones catalog objects from one merchant account to another.");
+  }
+
+  @Override
+  public void execute(CatalogApi sourceCatalogApi, LocationsApi locationsApi) throws ApiException {
+    // Prompt the user for configuration info.
+    Config config = promptForConfigurationOptions();
+
+    // Create a CatalogApi to access the target account.
+    CatalogApi targetCatalogApi =
+        createTargetCatalogApi(sourceCatalogApi, config.targetAccessToken);
+
+    try {
+       /*
+        * Clone discounts from source to target account.
+        *
+        * If a discount in the source account has the same name, discount type, percentage, and amount
+        * as a discount in the target account, then the discount in the source account is not cloned.
+        */
+      if (config.discountCloneUtil != null) {
+        cloneCatalogObjectType(sourceCatalogApi, targetCatalogApi, config.discountCloneUtil);
+      }
+
+      /*
+       * Clone modifier lists from source to target account.
+       *
+       * If a modifier list in the source account has the same name and selection type as a modifier
+       * list in the target account, then the modifier list in the source account is not cloned. In
+       * that case, the modifiers from the modifier list in the source account will be added to the
+       * modifier list in the target account if they do not match any of the existing modifiers.
+       */
+      if (config.modifierListCloneUtil != null) {
+        cloneCatalogObjectType(sourceCatalogApi, targetCatalogApi, config.modifierListCloneUtil);
+      }
+
+      /*
+       * Clone taxes from source to target account.
+       *
+       * If a tax in the source account has the same name, percentage, and inclusion type as a tax in
+       * the target account, then the tax in the source account is not cloned.
+       */
+      if (config.taxCloneUtil != null) {
+        cloneCatalogObjectType(sourceCatalogApi, targetCatalogApi, config.taxCloneUtil);
+      }
+    } catch (CloneCatalogException e) {
+      if (e.getMessage() != null) {
+        logger.error(e.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Prompt the user for configuration options required to clone the account.
+   *
+   * @return the configuration to apply when cloning accounts
+   */
+  private Config promptForConfigurationOptions() {
+    Config config = new Config();
+    config.targetAccessToken = promptUserInput("Enter access token of target account: ").trim();
+
+    if (promptUserInputYesNo("Clone all discounts (y/n)? ")) {
+      boolean presentAtAllLocationsByDefault =
+          promptUserInputYesNo("  Make cloned discounts available at all locations (y/n)? ");
+      config.discountCloneUtil = new DiscountCloneUtil(presentAtAllLocationsByDefault);
+    }
+
+    if (promptUserInputYesNo("Clone all modifier lists (y/n)? ")) {
+      logger.info("  Note: Modifier lists will be enabled at all locations");
+      config.modifierListCloneUtil = new ModifierListCloneUtil();
+    }
+
+    if (promptUserInputYesNo("Clone all taxes (y/n)? ")) {
+      config.taxCloneUtil = new TaxCloneUtil();
+    }
+
+    return config;
+  }
+
+  /**
+   * Create a CatalogApi instance to access the target account.
+   *
+   * @param sourceCatalogApi the {@link CatalogApi} instance used to access the source account
+   * @param targetAccessToken the access token of the target account
+   * @return a {@link CatalogApi} for the target account
+   */
+  private CatalogApi createTargetCatalogApi(CatalogApi sourceCatalogApi, String targetAccessToken) {
+    // Create a new instance of the ApiClient.
+    ApiClient targetApiClient = new ApiClient();
+    targetApiClient.setBasePath(sourceCatalogApi.getApiClient().getBasePath());
+
+    // Set the auth token of the ApiClient to the target account.
+    OAuth oauth2 = (OAuth) targetApiClient.getAuthentication("oauth2");
+    oauth2.setAccessToken(targetAccessToken);
+
+    // Return a new CatalogApi instance that uses the new ApiClient.
+    return new CatalogApi(targetApiClient);
+  }
+
+  /**
+   * Clones all catalog objects of a single type.
+   *
+   * The basic approach for cloning catalog objects is the same for all types other than items.
+   * 1) Fetch all the catalog objects of the specified type from the target account
+   * 2) For each object in the target account, generate a unique identifier based on certain field
+   * values. For example, for taxes we compare name, percentage, and inclusion type.
+   * 3) Store all unqiue identifiers in a HashSet
+   * 4) Fetch all the catalog objects of the specified type from the target account
+   * 5) For each object in the source account, generate a unique identifier using the same method
+   * and check to see if it exists in the HashSet. If it does not, then add it to the target
+   * account.
+   *
+   * @param sourceCatalogApi the API used to access the catalog of the source account
+   * @param targetCatalogApi the API used to access the catalog of the target account
+   * @param cloneUtil the clone utility methods for the specified catalog object type
+   */
+  private void cloneCatalogObjectType(CatalogApi sourceCatalogApi, CatalogApi targetCatalogApi,
+      CatalogObjectCloneUtil<?> cloneUtil)
+      throws ApiException, CloneCatalogException {
+    logger.info("\nCloning " + cloneUtil.type.toString());
+
+    // Retrieve identifiers from the target account.
+    HashMap<String, CatalogObject> targetCatalogObjects =
+        retrieveTargetCatalogObjects(targetCatalogApi, cloneUtil);
+
+    // Retrieve catalog objects from the source account.
+    logger.info("  Retrieving " + cloneUtil.type.toString() + " from source account");
+    String cursor = null;
+    do {
+      List<CatalogObject> catalogObjectsToUpsert = new ArrayList<>();
+
+      // Retrieve a page of catalog objects from the source account.
+      ListCatalogResponse listResponse =
+          sourceCatalogApi.listCatalog(cursor, cloneUtil.type.toString());
+      if (checkAndLogErrors(listResponse.getErrors())) {
+        throw new CloneCatalogException();
+      }
+
+      // Log and return if no objects are found.
+      if (listResponse.getObjects().isEmpty() && cursor == null) {
+        logger.info(
+            "No " + cloneUtil.type.toString().toLowerCase(Locale.US) + " found in source account.");
+        return;
+      }
+
+      for (CatalogObject sourceCatalogObject : listResponse.getObjects()) {
+        String encodedString = cloneUtil.encodeCatalogObject(sourceCatalogObject);
+
+        // Check if a similar catalog object already exists in the target account.
+        CatalogObject targetCatalogObject = targetCatalogObjects.get(encodedString);
+        if (targetCatalogObject == null) {
+          // Clone this CatalogObject into the target account.
+          cloneUtil.removeSourceAccountMetaData(sourceCatalogObject);
+          catalogObjectsToUpsert.add(sourceCatalogObject);
+        } else {
+          // If a similar CatalogObject already exists in the target account, attempt to merge the
+          // source CatalogObject into the existing target CatalogObject.
+          CatalogObject modifiedTargetCatalogObject =
+              cloneUtil.mergeSourceCatalogObjectIntoTarget(sourceCatalogObject,
+                  targetCatalogObject);
+
+          // If something changed in the target catalog object, upsert it into the target account.
+          if (modifiedTargetCatalogObject != null) {
+            catalogObjectsToUpsert.add(modifiedTargetCatalogObject);
+          }
+        }
+      }
+
+      // Upsert the catalog objects into the target account.
+      if (catalogObjectsToUpsert.size() > 0) {
+        upsertCatalogObjectsIntoTargetAccount(targetCatalogApi, catalogObjectsToUpsert);
+      }
+
+      // Log the number of objects cloned.
+      logger.info("    Cloned " + catalogObjectsToUpsert.size() +
+          " out of " + listResponse.getObjects().size());
+
+      // Move to the next page.
+      cursor = listResponse.getCursor();
+    } while (cursor != null);
+  }
+
+  /**
+   * Retrieves all of the CatalogObjects of the specified type from the target account and return
+   * them in a HashSet keyed by the encoded string.
+   *
+   * @param targetCatalogApi the API used to access the catalog of the target account
+   * @param cloneUtil the clone utility methods for the specified catalog object type
+   * @return a map of the encoded string to the {@link CatalogObject} in the target account
+   */
+  private HashMap<String, CatalogObject> retrieveTargetCatalogObjects(CatalogApi
+      targetCatalogApi,
+      CatalogObjectCloneUtil<?> cloneUtil) throws ApiException, CloneCatalogException {
+    logger.info("  Retrieving " + cloneUtil.type.toString() + " from target account");
+    HashMap<String, CatalogObject> identifierToCatalogObject = new HashMap<>();
+    int count = 0;
+    String cursor = null;
+    do {
+      // Retrieve a page of catalog objects.
+      ListCatalogResponse listResponse =
+          targetCatalogApi.listCatalog(cursor, cloneUtil.type.toString());
+      if (checkAndLogErrors(listResponse.getErrors())) {
+        throw new CloneCatalogException();
+      }
+
+      // Generate an encoded string for each object and add it to the hash map.
+      for (CatalogObject catalogObject : listResponse.getObjects()) {
+        String encodedString = cloneUtil.encodeCatalogObject(catalogObject);
+        identifierToCatalogObject.put(encodedString, catalogObject);
+      }
+
+      // Move to the next page.
+      count += listResponse.getObjects().size();
+      logger.info("    Retrieved " + count + " total");
+      cursor = listResponse.getCursor();
+    } while (cursor != null);
+
+    return identifierToCatalogObject;
+  }
+
+  /**
+   * Inserts or updates catalog objects into the target account.
+   *
+   * @param targetCatalogApi the API used to access the catalog of the target account
+   * @param catalogObjectsToUpsert the CatalogObjects to insert or update
+   */
+
+  private void upsertCatalogObjectsIntoTargetAccount(CatalogApi targetCatalogApi,
+      List<CatalogObject> catalogObjectsToUpsert) throws ApiException, CloneCatalogException {
+    BatchUpsertCatalogObjectsRequest batchUpsertRequest = new BatchUpsertCatalogObjectsRequest()
+        .idempotencyKey(UUID.randomUUID().toString())
+        .addBatchesItem(new CatalogObjectBatch()
+            .objects(catalogObjectsToUpsert)
+        );
+    BatchUpsertCatalogObjectsResponse batchUpsertResponse =
+        targetCatalogApi.batchUpsertCatalogObjects(batchUpsertRequest);
+    if (checkAndLogErrors(batchUpsertResponse.getErrors())) {
+      throw new CloneCatalogException();
+    }
+  }
+
+  /**
+   * User specified configuration options.
+   */
+  private static class Config {
+    private String targetAccessToken;
+    private DiscountCloneUtil discountCloneUtil;
+    private ModifierListCloneUtil modifierListCloneUtil;
+    private TaxCloneUtil taxCloneUtil;
+  }
+}

--- a/src/main/java/com/squareup/catalog/demo/example/clone/CloneCatalogException.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/CloneCatalogException.java
@@ -1,0 +1,10 @@
+package com.squareup.catalog.demo.example.clone;
+
+/**
+ * Exception thrown when cloning fails.
+ */
+class CloneCatalogException extends Exception {
+  CloneCatalogException() {
+    super();
+  }
+}

--- a/src/main/java/com/squareup/catalog/demo/example/clone/DiscountCloneUtil.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/DiscountCloneUtil.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogDiscount;
+import com.squareup.connect.models.CatalogObject;
+
+import static com.squareup.connect.models.CatalogObject.TypeEnum.DISCOUNT;
+
+/**
+ * Utility methods used to clone a {@link CatalogDiscount}.
+ */
+class DiscountCloneUtil extends CatalogObjectCloneUtil<CatalogDiscount> {
+
+  private final boolean presentAtAllLocationsByDefault;
+
+  DiscountCloneUtil(boolean presentAtAllLocationsByDefault) {
+    super(DISCOUNT);
+    this.presentAtAllLocationsByDefault = presentAtAllLocationsByDefault;
+  }
+
+  @Override CatalogDiscount getCatalogData(CatalogObject catalogObject) {
+    return catalogObject.getDiscountData();
+  }
+
+  @Override String encodeCatalogData(CatalogDiscount discount) {
+    return discount.getName()
+        + ":::"
+        + discount.getDiscountType()
+        + ":::"
+        + discount.getPercentage()
+        + ":::"
+        + amountOrNull(discount.getAmountMoney());
+  }
+
+  @Override void removeSourceAccountMetaData(CatalogObject catalogObject) {
+    super.removeSourceAccountMetaData(catalogObject);
+    if (presentAtAllLocationsByDefault) {
+      catalogObject.setPresentAtAllLocations(presentAtAllLocationsByDefault);
+    }
+  }
+}

--- a/src/main/java/com/squareup/catalog/demo/example/clone/ModifierListCloneUtil.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/ModifierListCloneUtil.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogModifier;
+import com.squareup.connect.models.CatalogModifierList;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.Money;
+import java.util.HashSet;
+
+/**
+ * Utility methods used to clone a {@link CatalogModifierList}.
+ */
+class ModifierListCloneUtil extends CatalogObjectCloneUtil<CatalogModifierList> {
+
+  ModifierListCloneUtil() {
+    super(CatalogObject.TypeEnum.MODIFIER_LIST);
+  }
+
+  @Override CatalogModifierList getCatalogData(CatalogObject catalogObject) {
+    return catalogObject.getModifierListData();
+  }
+
+  @Override public String encodeCatalogData(CatalogModifierList modifierList) {
+    return modifierList.getName() + ":::" + modifierList.getSelectionType();
+  }
+
+  @Override
+  void removeSourceAccountMetaData(CatalogObject catalogObject) {
+    super.removeSourceAccountMetaData(catalogObject);
+
+    // Make modifier lists available at all locations by default.
+    catalogObject.setPresentAtAllLocations(true);
+
+    // Also remove meta data from the embedded modifiers.
+    CatalogModifierList modifierList = catalogObject.getModifierListData();
+    for (CatalogObject modifierObject : modifierList.getModifiers()) {
+      removeSourceAccountMetaDataFromModifier(modifierObject, catalogObject);
+    }
+  }
+
+  @Override
+  CatalogObject mergeSourceCatalogObjectIntoTarget(CatalogObject sourceCatalogObject,
+      CatalogObject targetCatalogObject) {
+    // Create a HashSet of the modifiers in the target modifier list.
+    CatalogModifierList targetModifierList = targetCatalogObject.getModifierListData();
+    HashSet<String> targetModifiers = getEncodedModifiers(targetModifierList);
+
+    // Add modifiers from the source modifier list that are not already in the target list.
+    boolean addedModifierToTarget = false;
+    CatalogModifierList sourceModifierList = sourceCatalogObject.getModifierListData();
+    for (CatalogObject modifierObject : sourceModifierList.getModifiers()) {
+      String encodeModifier = encodeModifier(modifierObject);
+      if (!targetModifiers.contains(encodeModifier)) {
+        // Prepare the catalog object for the target account.
+        removeSourceAccountMetaDataFromModifier(modifierObject, targetCatalogObject);
+
+        // Add the modifier to the target modifier list.
+        targetModifierList.addModifiersItem(modifierObject);
+
+        // Mark that we've updated the target modifier list.
+        addedModifierToTarget = true;
+      }
+    }
+
+    // Return the modifier target CatalogObject if it changed.
+    return addedModifierToTarget ? targetCatalogObject : null;
+  }
+
+  /**
+   * Returns a set of all encoded modifiers in the modifier list.
+   */
+  private HashSet<String> getEncodedModifiers(CatalogModifierList modifierList) {
+    HashSet<String> encodedModifiers = new HashSet<>();
+    for (CatalogObject modifierObject : modifierList.getModifiers()) {
+      encodedModifiers.add(encodeModifier(modifierObject));
+    }
+    return encodedModifiers;
+  }
+
+  private String encodeModifier(CatalogObject modifierObject) {
+    CatalogModifier modifier = modifierObject.getModifierData();
+
+    // If the price is null, coerece it to 0. A null price is the same as a $0 price.
+    Money price = modifier.getPriceMoney();
+    long amount = (price == null) ? 0 : price.getAmount();
+
+    return modifier.getName() + ":::" + amount;
+  }
+
+  /**
+   * Removes meta data from the {@link CatalogObject} that only applies to the source account, such
+   * as location IDs and version. Also matches locations with the parent modifier list.
+   */
+  private void removeSourceAccountMetaDataFromModifier(CatalogObject modifier,
+      CatalogObject modifierList) {
+    super.removeSourceAccountMetaData(modifier);
+
+    // Make the locations of the modifier match the locations of the modifier list.
+    modifier.setPresentAtAllLocations(modifierList.getPresentAtAllLocations());
+    modifier.setPresentAtLocationIds(modifierList.getPresentAtLocationIds());
+    modifier.setAbsentAtLocationIds(modifierList.getAbsentAtLocationIds());
+  }
+}

--- a/src/main/java/com/squareup/catalog/demo/example/clone/TaxCloneUtil.java
+++ b/src/main/java/com/squareup/catalog/demo/example/clone/TaxCloneUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogDiscount;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.CatalogTax;
+
+import static com.squareup.connect.models.CatalogObject.TypeEnum.TAX;
+
+/**
+ * Utility methods used to clone a {@link CatalogDiscount}.
+ */
+class TaxCloneUtil extends CatalogObjectCloneUtil<CatalogTax> {
+
+  TaxCloneUtil() {
+    super(TAX);
+  }
+
+  @Override CatalogTax getCatalogData(CatalogObject catalogObject) {
+    return catalogObject.getTaxData();
+  }
+
+  @Override String encodeCatalogData(CatalogTax tax) {
+    return tax.getName() + ":::" + tax.getPercentage() + ":::" + tax.getInclusionType();
+  }
+}

--- a/src/test/java/com/squareup/catalog/demo/example/clone/DiscountCloneUtilTest.java
+++ b/src/test/java/com/squareup/catalog/demo/example/clone/DiscountCloneUtilTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.catalog.demo.util.Moneys;
+import com.squareup.connect.models.CatalogDiscount;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.squareup.connect.models.CatalogDiscount.DiscountTypeEnum.FIXED_AMOUNT;
+import static com.squareup.connect.models.CatalogDiscount.DiscountTypeEnum.FIXED_PERCENTAGE;
+import static com.squareup.connect.models.CatalogDiscount.DiscountTypeEnum.VARIABLE_AMOUNT;
+import static com.squareup.connect.models.CatalogDiscount.DiscountTypeEnum.VARIABLE_PERCENTAGE;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class DiscountCloneUtilTest {
+
+  private DiscountCloneUtil cloneUtil;
+
+  @Before public void setUp() {
+    this.cloneUtil = new DiscountCloneUtil(false);
+  }
+
+  @Test public void encodeCatalogData_fixedAmount() {
+    CatalogDiscount discount = new CatalogDiscount()
+        .name("name")
+        .discountType(FIXED_AMOUNT)
+        .percentage(null)
+        .amountMoney(Moneys.usd(1000));
+    assertThat(cloneUtil.encodeCatalogData(discount)).isEqualTo(
+        "name:::FIXED_AMOUNT:::null:::1000");
+  }
+
+  @Test public void encodeCatalogData_fixedPercentage() {
+    CatalogDiscount discount = new CatalogDiscount()
+        .name("name")
+        .discountType(FIXED_PERCENTAGE)
+        .percentage("12.34")
+        .amountMoney(null);
+    assertThat(cloneUtil.encodeCatalogData(discount)).isEqualTo(
+        "name:::FIXED_PERCENTAGE:::12.34:::null");
+  }
+
+  @Test public void encodeCatalogData_variableAmount() {
+    CatalogDiscount discount = new CatalogDiscount()
+        .name("name")
+        .discountType(VARIABLE_AMOUNT)
+        .percentage(null)
+        .amountMoney(null);
+    assertThat(cloneUtil.encodeCatalogData(discount)).isEqualTo(
+        "name:::VARIABLE_AMOUNT:::null:::null");
+  }
+
+  @Test public void encodeCatalogData_variablePercentage() {
+    CatalogDiscount discount = new CatalogDiscount()
+        .name("name")
+        .discountType(VARIABLE_PERCENTAGE)
+        .percentage(null)
+        .amountMoney(null);
+    assertThat(cloneUtil.encodeCatalogData(discount)).isEqualTo(
+        "name:::VARIABLE_PERCENTAGE:::null:::null");
+  }
+}

--- a/src/test/java/com/squareup/catalog/demo/example/clone/ModifierListCloneUtilTest.java
+++ b/src/test/java/com/squareup/catalog/demo/example/clone/ModifierListCloneUtilTest.java
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogModifier;
+import com.squareup.connect.models.CatalogModifierList;
+import com.squareup.connect.models.CatalogObject;
+import com.squareup.connect.models.Money;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.squareup.catalog.demo.util.Moneys.usd;
+import static com.squareup.connect.models.CatalogModifierList.SelectionTypeEnum.MULTIPLE;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class ModifierListCloneUtilTest {
+
+  private ModifierListCloneUtil cloneUtil;
+
+  @Before public void setUp() {
+    this.cloneUtil = new ModifierListCloneUtil();
+  }
+
+  @Test public void encodeCatalogData() {
+    CatalogModifierList modifierList = new CatalogModifierList()
+        .name("name")
+        .selectionType(MULTIPLE);
+    assertThat(cloneUtil.encodeCatalogData(modifierList)).isEqualTo("name:::MULTIPLE");
+  }
+
+  @Test public void removeSourceAccountMetaData_modifiersMatchModifierList() {
+    CatalogObject modifier0 = createModifier("modifier0", null)
+        .presentAtAllLocations(false) //
+        .addPresentAtLocationIdsItem("sourceLocation1");
+    CatalogObject modifier1 = createModifier("modifier1", null)
+        .presentAtAllLocations(false) //
+        .addPresentAtLocationIdsItem("sourceLocation1");
+    CatalogObject modifierList = new CatalogObject()
+        .presentAtAllLocations(false) //
+        .addPresentAtLocationIdsItem("sourceLocation1")
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(modifier0)
+            .addModifiersItem(modifier1));
+    cloneUtil.removeSourceAccountMetaData(modifierList);
+    assertThat(modifierList.getPresentAtAllLocations()).isTrue();
+    assertThat(modifierList.getPresentAtLocationIds()).isEmpty();
+    assertThat(modifier0.getPresentAtAllLocations()).isTrue();
+    assertThat(modifier0.getPresentAtLocationIds()).isEmpty();
+    assertThat(modifier1.getPresentAtAllLocations()).isTrue();
+    assertThat(modifier1.getPresentAtLocationIds()).isEmpty();
+  }
+
+  @Test public void mergeSourceCatalogObjectIntoTarget_appendsNewModifiers() {
+    CatalogObject sourceModifierList = new CatalogObject()
+        .presentAtAllLocations(false) //
+        .addPresentAtLocationIdsItem("sourceLocation1")
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("foo", null)
+                .presentAtAllLocations(false) //
+                .addPresentAtLocationIdsItem("sourceLocation1"))
+            .addModifiersItem(createModifier("bar", null)
+                .presentAtAllLocations(false) //
+                .addPresentAtLocationIdsItem("sourceLocation1")));
+    CatalogObject targetModifierList = new CatalogObject()
+        .presentAtAllLocations(true) //
+        .addPresentAtLocationIdsItem("targetLocation1")
+        .addAbsentAtLocationIdsItem("targetLocation2")
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("bar", null)
+                .presentAtAllLocations(true) //
+                .addPresentAtLocationIdsItem("targetLocation1")
+                .addAbsentAtLocationIdsItem("targetLocation2"))
+            .addModifiersItem(createModifier("baz", null)
+                .presentAtAllLocations(true) //
+                .addPresentAtLocationIdsItem("targetLocation1")
+                .addAbsentAtLocationIdsItem("targetLocation2")));
+
+    CatalogObject resultObject =
+        cloneUtil.mergeSourceCatalogObjectIntoTarget(sourceModifierList, targetModifierList);
+    assertThat(resultObject.getPresentAtAllLocations()).isTrue();
+    assertThat(resultObject.getPresentAtLocationIds()).containsExactly("targetLocation1");
+    assertThat(resultObject.getAbsentAtLocationIds()).containsExactly("targetLocation2");
+
+    CatalogModifierList resultModifierList = resultObject.getModifierListData();
+    assertThat(resultModifierList.getModifiers()).hasSize(3);
+
+    CatalogObject resultModifier0 = resultModifierList.getModifiers().get(0);
+    assertThat(resultModifier0.getPresentAtAllLocations()).isTrue();
+    assertThat(resultModifier0.getPresentAtLocationIds()).containsExactly("targetLocation1");
+    assertThat(resultModifier0.getAbsentAtLocationIds()).containsExactly("targetLocation2");
+    assertThat(resultModifier0.getModifierData().getName()).isEqualTo("bar");
+    CatalogObject resultModifier1 = resultModifierList.getModifiers().get(1);
+    assertThat(resultModifier1.getPresentAtAllLocations()).isTrue();
+    assertThat(resultModifier1.getPresentAtLocationIds()).containsExactly("targetLocation1");
+    assertThat(resultModifier1.getAbsentAtLocationIds()).containsExactly("targetLocation2");
+    assertThat(resultModifier1.getModifierData().getName()).isEqualTo("baz");
+    CatalogObject resultModifier2 = resultModifierList.getModifiers().get(2);
+    assertThat(resultModifier2.getPresentAtAllLocations()).isTrue();
+    assertThat(resultModifier2.getPresentAtLocationIds()).containsExactly("targetLocation1");
+    assertThat(resultModifier2.getAbsentAtLocationIds()).containsExactly("targetLocation2");
+    assertThat(resultModifier2.getModifierData().getName()).isEqualTo("foo");
+  }
+
+  @Test public void mergeSourceCatalogObjectIntoTarget_coercesNullAmountToZero() {
+    CatalogObject sourceModifierList = new CatalogObject()
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("name", null)));
+    CatalogObject targetModifierList = new CatalogObject()
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("name", 0L)));
+
+    CatalogObject resultObject =
+        cloneUtil.mergeSourceCatalogObjectIntoTarget(sourceModifierList, targetModifierList);
+    assertThat(resultObject).isNull();
+  }
+
+  @Test public void mergeSourceCatalogObjectIntoTarget_addsModifierIfPriceDifferent() {
+    CatalogObject sourceModifierList = new CatalogObject()
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("name", 0L)));
+    CatalogObject targetModifierList = new CatalogObject()
+        .modifierListData(new CatalogModifierList()
+            .addModifiersItem(createModifier("name", 100L)));
+
+    CatalogObject resultObject =
+        cloneUtil.mergeSourceCatalogObjectIntoTarget(sourceModifierList, targetModifierList);
+    CatalogModifierList resultModifierList = resultObject.getModifierListData();
+    assertThat(resultModifierList.getModifiers()).hasSize(2);
+
+    CatalogObject resultModifier0 = resultModifierList.getModifiers().get(0);
+    assertThat(resultModifier0.getModifierData().getName()).isEqualTo("name");
+    assertThat(resultModifier0.getModifierData().getPriceMoney().getAmount()).isEqualTo(100L);
+    CatalogObject resultModifier1 = resultModifierList.getModifiers().get(1);
+    assertThat(resultModifier1.getModifierData().getName()).isEqualTo("name");
+    assertThat(resultModifier1.getModifierData().getPriceMoney().getAmount()).isEqualTo(0L);
+  }
+
+  private CatalogObject createModifier(String name, Long priceAmount) {
+    Money priceMoney = (priceAmount == null) ? null : usd(priceAmount);
+    return new CatalogObject()
+        .modifierData(new CatalogModifier()
+            .name(name)
+            .priceMoney(priceMoney));
+  }
+}

--- a/src/test/java/com/squareup/catalog/demo/example/clone/TaxCloneUtilTest.java
+++ b/src/test/java/com/squareup/catalog/demo/example/clone/TaxCloneUtilTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.catalog.demo.example.clone;
+
+import com.squareup.connect.models.CatalogTax;
+import org.junit.Before;
+import org.junit.Test;
+
+import static com.squareup.connect.models.CatalogTax.InclusionTypeEnum.ADDITIVE;
+import static org.fest.assertions.Assertions.assertThat;
+
+public class TaxCloneUtilTest {
+
+  private TaxCloneUtil cloneUtil;
+
+  @Before public void setUp() {
+    this.cloneUtil = new TaxCloneUtil();
+  }
+
+  @Test public void encodeCatalogData() {
+    CatalogTax tax = new CatalogTax()
+        .name("name")
+        .percentage("12.34")
+        .inclusionType(ADDITIVE);
+    assertThat(cloneUtil.encodeCatalogData(tax)).isEqualTo("name:::12.34:::ADDITIVE");
+  }
+}


### PR DESCRIPTION
For now, this example only clones discounts, modifiers, and taxes. Soon it will also clone the Item Library, including memberships.